### PR TITLE
MMA-10527: Update requirements for py3

### DIFF
--- a/rabl/rabl.py
+++ b/rabl/rabl.py
@@ -88,7 +88,7 @@ class RequestHandler(spoon.server.UDPGulp):
         """Handle a single incoming connection."""
         logger = logging.getLogger("rabl")
         logger.debug("Handling report from %s", self.client_address[0])
-        packet = self.rfile.read(320000).strip()
+        packet = self.rfile.read(320000).strip().decode("utf-8", errors="strict")
 
         # claimed_reporter is an IP address when from the trusted IP, or ""
         # otherwise.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-dnspython==1.16.0 ; python_version < "3"
-idna==2.10 ; python_version < "3"
-ipaddr==2.2.0 ; python_version < "3"
-mysqlclient==1.4.6 ; python_version < "3"
-sentry-sdk==1.10.1 ; python_version < "3"
-spoon==1.0.6 ; python_version < "3"
-Click==7.1.2 ; python_version < "3"
+dnspython==2.8.0
+idna==3.11
+ipaddr==2.2.0
+mysqlclient==2.2.7
+sentry-sdk==2.44.0
+spoon==1.0.7
+click==8.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+certifi==2025.11.12
+click==8.3.1
 dnspython==2.8.0
 idna==3.11
 ipaddr==2.2.0
 mysqlclient==2.2.7
-sentry-sdk==2.44.0
+sentry-sdk==2.48.0
 spoon==1.0.7
-click==8.3.0
+urllib3==2.6.2


### PR DESCRIPTION
Bump requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependencies for Python 3 and decodes incoming UDP report packets as UTF-8 before parsing.
> 
> - **Server behavior**:
>   - Decode `packet` from `self.rfile.read(...).strip()` using UTF-8 (strict) in `rabl/rabl.py` before parsing.
> - **Dependencies**:
>   - Overhaul `requirements.txt` for Python 3: add `certifi`, `urllib3`; upgrade `click`, `dnspython`, `idna`, `mysqlclient`, `sentry-sdk`, `spoon`; remove Python 2 conditionals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1709209a846deb3b308b21557d7eaf8ad6ce67be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->